### PR TITLE
Add Summary Collector

### DIFF
--- a/src/Prometheus/CollectorRegistry.php
+++ b/src/Prometheus/CollectorRegistry.php
@@ -252,7 +252,7 @@ class CollectorRegistry
      * @return Summary
      * @throws MetricsRegistrationException
      */
-    public function registerSummary($namespace, $name, $help, $labels = [], $quantiles = null): Summary
+    public function registerSummary(string $namespace, string $name, string $help, array $labels = [], ?array $quantiles = null): Summary
     {
         $metricIdentifier = self::metricIdentifier($namespace, $name);
         if (isset($this->summaries[$metricIdentifier])) {
@@ -275,7 +275,7 @@ class CollectorRegistry
      * @return Summary
      * @throws MetricNotFoundException
      */
-    public function getSummary($namespace, $name): Summary
+    public function getSummary(string $namespace, string $name): Summary
     {
         $metricIdentifier = self::metricIdentifier($namespace, $name);
         if (!isset($this->summaries[$metricIdentifier])) {
@@ -293,7 +293,7 @@ class CollectorRegistry
      * @return Summary
      * @throws MetricsRegistrationException
      */
-    public function getOrRegisterSummary($namespace, $name, $help, $labels = [], $quantiles = null): Summary
+    public function getOrRegisterSummary(string $namespace, string $name, string $help, array $labels = [], ?array $quantiles = null): Summary
     {
         try {
             $summary = $this->getSummary($namespace, $name);

--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -62,6 +62,14 @@ class APC implements Adapter
     /**
      * @param array $data
      */
+    public function updateSummary(array $data)
+    {
+        // TODO: Implement updateSummary() method.
+    }
+
+    /**
+     * @param array $data
+     */
     public function updateGauge(array $data): void
     {
         $valueKey = $this->valueKey($data);

--- a/src/Prometheus/Storage/Adapter.php
+++ b/src/Prometheus/Storage/Adapter.php
@@ -27,6 +27,12 @@ interface Adapter
      * @param array $data
      * @return void
      */
+    public function updateSummary(array $data): void;
+
+    /**
+     * @param array $data
+     * @return void
+     */
     public function updateGauge(array $data): void;
 
     /**

--- a/src/Prometheus/Storage/InMemory.php
+++ b/src/Prometheus/Storage/InMemory.php
@@ -177,6 +177,15 @@ class InMemory implements Adapter
 
     /**
      * @param array $data
+     * @return void
+     */
+    public function updateSummary(array $data): void
+    {
+        // TODO: Implement updateSummary() method.
+    }
+
+    /**
+     * @param array $data
      */
     public function updateGauge(array $data): void
     {

--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -210,7 +210,8 @@ LUA
         $metaData = $data;
         unset($metaData['value']);
         unset($metaData['labelValues']);
-        $this->redis->eval(<<<LUA
+        $this->redis->eval(
+            <<<LUA
 local increment = redis.call('hIncrByFloat', KEYS[1], KEYS[2], ARGV[1])
 redis.call('hIncrBy', KEYS[1], KEYS[3], 1)
 local values = redis.call('hGet', KEYS[1], KEYS[4])
@@ -418,7 +419,7 @@ LUA
             foreach ($allLabelValues as $labelValues) {
                 $valuesKey = json_encode(['b' => 'values', 'labelValues' => $labelValues]);
                 $values = !empty($raw[$valuesKey]) ? explode(',', $raw[$valuesKey]) : [];
-                foreach($summary['quantiles'] as $quantile) {
+                foreach ($summary['quantiles'] as $quantile) {
                     $summary['samples'][] = [
                         'name' => $summary['name'],
                         'labelNames' => ['quantile'],

--- a/src/Prometheus/Summary.php
+++ b/src/Prometheus/Summary.php
@@ -1,0 +1,107 @@
+<?php
+declare(strict_types=1);
+
+namespace Prometheus;
+
+use InvalidArgumentException;
+use Prometheus\Storage\Adapter;
+
+class Summary extends Collector
+{
+    const TYPE = 'summary';
+
+    /**
+     * @var array|null
+     */
+    private $quantiles;
+
+    /**
+     * @param Adapter $adapter
+     * @param string $namespace
+     * @param string $name
+     * @param string $help
+     * @param array $labels
+     * @param array $quantiles
+     * @throws InvalidArgumentException
+     */
+    public function __construct(Adapter $adapter, $namespace, $name, $help, $labels = [], $quantiles = null)
+    {
+        parent::__construct($adapter, $namespace, $name, $help, $labels);
+
+        if (null === $quantiles) {
+            $quantiles = self::getDefaultQuantiles();
+        }
+
+        if (0 === count($quantiles)) {
+            throw new InvalidArgumentException('Summary must have at least one quantile.');
+        }
+
+        for ($i = 0; $i < count($quantiles) - 1; $i++) {
+            if ($quantiles[$i] >= $quantiles[$i + 1]) {
+                throw new InvalidArgumentException(
+                    'Summary quantiles must be in increasing order: ' .
+                    $quantiles[$i] . ' >= ' . $quantiles[$i + 1]
+                );
+            }
+        }
+        foreach ($labels as $label) {
+            if ($label === 'quantile') {
+                throw new InvalidArgumentException('Summary cannot have a label named "quantile".');
+            }
+        }
+        $this->quantiles = $quantiles;
+    }
+
+    /**
+     * List of default quantiles
+     * @return array
+     */
+    public static function getDefaultQuantiles(): array
+    {
+        return [
+            0.01, 0.05, 0.5, 0.9, 0.99,
+        ];
+    }
+
+    /**
+     * @param double $value e.g. 123
+     * @param array $labels e.g. ['status', 'opcode']
+     */
+    public function observe($value, $labels = []): void
+    {
+        $this->assertLabelsAreDefinedCorrectly($labels);
+        $this->storageAdapter->updateSummary(
+            [
+                'value' => $value,
+                'name' => $this->getName(),
+                'help' => $this->getHelp(),
+                'type' => $this->getType(),
+                'labelNames' => $this->getLabelNames(),
+                'labelValues' => $labels,
+                'quantiles' => $this->quantiles,
+            ]
+        );
+    }
+
+    /**
+     * @param float $percentile
+     * @param array $values
+     * @return float
+     */
+    public static function getQuantile($percentile, $values): float
+    {
+        sort($values);
+        $index = (int)($percentile * count($values));
+        return (floor($index) === $index)
+            ? ($values[$index - 1] + $values[$index]) / 2
+            : $result = $values[(int)floor($index)];
+    }
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+}

--- a/src/Prometheus/Summary.php
+++ b/src/Prometheus/Summary.php
@@ -88,13 +88,13 @@ class Summary extends Collector
      * @param array $values
      * @return float
      */
-    public static function getQuantile($percentile, $values): float
+    public static function getQuantile($percentile, $values)
     {
         sort($values);
         $index = (int)($percentile * count($values));
         return (floor($index) === $index)
             ? ($values[$index - 1] + $values[$index]) / 2
-            : $result = $values[(int)floor($index)];
+            : $values[(int)floor($index)];
     }
 
     /**

--- a/src/Prometheus/Summary.php
+++ b/src/Prometheus/Summary.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Prometheus;
@@ -67,7 +68,7 @@ class Summary extends Collector
      * @param double $value e.g. 123
      * @param array $labels e.g. ['status', 'opcode']
      */
-    public function observe($value, $labels = []): void
+    public function observe(float $value, array $labels = []): void
     {
         $this->assertLabelsAreDefinedCorrectly($labels);
         $this->storageAdapter->updateSummary(
@@ -88,7 +89,7 @@ class Summary extends Collector
      * @param array $values
      * @return float
      */
-    public static function getQuantile($percentile, $values)
+    public static function getQuantile(float $percentile, array $values)
     {
         sort($values);
         $index = (int)($percentile * count($values));

--- a/src/Prometheus/Summary.php
+++ b/src/Prometheus/Summary.php
@@ -25,7 +25,7 @@ class Summary extends Collector
      * @param array $quantiles
      * @throws InvalidArgumentException
      */
-    public function __construct(Adapter $adapter, $namespace, $name, $help, $labels = [], $quantiles = null)
+    public function __construct(Adapter $adapter, string $namespace, string $name, string $help, array $labels = [], ?array $quantiles = null)
     {
         parent::__construct($adapter, $namespace, $name, $help, $labels);
 
@@ -89,13 +89,13 @@ class Summary extends Collector
      * @param array $values
      * @return float
      */
-    public static function getQuantile(float $percentile, array $values)
+    public static function getQuantile(float $percentile, array $values): float
     {
         sort($values);
         $index = (int)($percentile * count($values));
         return (floor($index) === $index)
             ? ($values[$index - 1] + $values[$index]) / 2
-            : $values[(int)floor($index)];
+            : (float) $values[(int)floor($index)];
     }
 
     /**


### PR DESCRIPTION
This is basically [buffcode's code](https://github.com/buffcode/prometheus_client_php/commits/summary-collector) slightly tweaked to make it mergeable with this fork.

There are no tests and the only storage adapter that is implemented is Redis, so I wouldn't say it's ready for a merge just yet.

I'll try to get some time to take a look at tests and the other storage adapters, but I'm not sure when that might be. If someone else would like to take a look at it, they're more than welcome. 🙂 