### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: php
-php:
-  - 5.6
-  - 7.0
-  - 7.1
+php: 
+  - 7.3
+  - 7.4
 
 services:
   - redis-server


### PR DESCRIPTION
Run tests for PHP 7.3 and 7.4, no more support for < 7.3 (required in composer)