### PR TITLE
Add support for prometheus/pushgateway:>=0.10

### DIFF
--- a/src/Prometheus/PushGateway.php
+++ b/src/Prometheus/PushGateway.php
@@ -39,7 +39,7 @@ class PushGateway
      * @param array $groupingKey
      * @throws GuzzleException
      */
-    public function push(CollectorRegistry $collectorRegistry, string $job, array $groupingKey = null): void
+    public function push(CollectorRegistry $collectorRegistry, string $job, array $groupingKey = []): void
     {
         $this->doRequest($collectorRegistry, $job, $groupingKey, 'put');
     }
@@ -52,7 +52,7 @@ class PushGateway
      * @param $groupingKey
      * @throws GuzzleException
      */
-    public function pushAdd(CollectorRegistry $collectorRegistry, string $job, array $groupingKey = null): void
+    public function pushAdd(CollectorRegistry $collectorRegistry, string $job, array $groupingKey = []): void
     {
         $this->doRequest($collectorRegistry, $job, $groupingKey, 'post');
     }
@@ -64,7 +64,7 @@ class PushGateway
      * @param array $groupingKey
      * @throws GuzzleException
      */
-    public function delete(string $job, array $groupingKey = null): void
+    public function delete(string $job, array $groupingKey = []): void
     {
         $this->doRequest(null, $job, $groupingKey, 'delete');
     }
@@ -92,6 +92,7 @@ class PushGateway
             'connect_timeout' => 10,
             'timeout' => 20,
         ];
+
         if ($method != 'delete') {
             $renderer = new RenderTextFormat();
             $requestOptions['body'] = $renderer->render($collectorRegistry->getMetricFamilySamples());

--- a/src/Prometheus/PushGateway.php
+++ b/src/Prometheus/PushGateway.php
@@ -99,7 +99,7 @@ class PushGateway
         }
         $response = $this->client->request($method, $url, $requestOptions);
         $statusCode = $response->getStatusCode();
-        if ($statusCode !== 200 && $statusCode !== 202) {
+        if (!in_array($statusCode, [200, 202])) {
             $msg = "Unexpected status code "
                 . $statusCode
                 . " received from push gateway "

--- a/tests/Test/Prometheus/PushGatewayTest.php
+++ b/tests/Test/Prometheus/PushGatewayTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Test\Prometheus;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Prometheus\CollectorRegistry;
+use Prometheus\MetricFamilySamples;
+use Prometheus\PushGateway;
+
+class PushGatewayTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @doesNotPerformAssertions
+     */
+    public function validResponseShouldNotThrowException(): void
+    {
+        $mockedCollectorRegistry = $this->createMock(CollectorRegistry::class);
+        $mockedCollectorRegistry->method('getMetricFamilySamples')->with()->willReturn([
+            $this->createMock(MetricFamilySamples::class)
+        ]);
+
+        $mockHandler = new MockHandler([
+            new Response(200),
+            new Response(202),
+        ]);
+        $handler = HandlerStack::create($mockHandler);
+        $client = new Client(['handler' => $handler]);
+
+        $pushGateway = new PushGateway('http://foo.bar', $client);
+        $pushGateway->push($mockedCollectorRegistry, 'foo');
+    }
+
+    /**
+     * @test
+     *
+     * @doesNotPerformAnyAssertions
+     */
+    public function invalidResponseShouldThrowRuntimeException(): void
+    {
+        $this->expectException(\RuntimeException::class);
+
+        $mockedCollectorRegistry = $this->createMock(CollectorRegistry::class);
+        $mockedCollectorRegistry->method('getMetricFamilySamples')->with()->willReturn([
+            $this->createMock(MetricFamilySamples::class)
+        ]);
+
+        $mockHandler = new MockHandler([
+            new Response(201),
+            new Response(300),
+        ]);
+        $handler = HandlerStack::create($mockHandler);
+        $client = new Client(['handler' => $handler]);
+
+        $pushGateway = new PushGateway('http://foo.bar', $client);
+        $pushGateway->push($mockedCollectorRegistry, 'foo');
+    }
+
+    /**
+     * @test
+     */
+    public function clientGetsDefinedIfNotSpecified(): void
+    {
+        $this->expectException(\RuntimeException::class);
+
+        $mockedCollectorRegistry = $this->createMock(CollectorRegistry::class);
+        $mockedCollectorRegistry->method('getMetricFamilySamples')->with()->willReturn([
+            $this->createMock(MetricFamilySamples::class)
+        ]);
+
+        $pushGateway = new PushGateway('http://foo.bar');
+        $pushGateway->push($mockedCollectorRegistry, 'foo');
+    }
+}


### PR DESCRIPTION
The prometheus/pushgateway release 0.10. changed the response status code when pushing metrics from 202 to 200 (see: https://github.com/prometheus/pushgateway/releases/tag/v0.10.0).

This fix it and let it downwards compatible for older pushgateway releases.
I've also added some tests and added the guzzlehttp/client per injection for easier testing. 
Additionally I've fixed an issue with wrong type declerations of groupingKeys.

Closes #15 
Closes #16