### PR TITLE
Add transport method to url

### DIFF
--- a/tests/Test/BlackBoxPushGatewayTest.php
+++ b/tests/Test/BlackBoxPushGatewayTest.php
@@ -28,7 +28,7 @@ class BlackBoxPushGatewayTest extends TestCase
         $counter = $registry->registerCounter('test', 'some_counter', 'it increases', ['type']);
         $counter->incBy(6, ['blue']);
 
-        $pushGateway = new PushGateway('pushgateway:9091', $transport);
+        $pushGateway = new PushGateway('pushgateway:9091', null, $transport);
         $pushGateway->push($registry, 'my_job', ['instance' => 'foo']);
 
         $client = new Client();

--- a/tests/Test/BlackBoxTest.php
+++ b/tests/Test/BlackBoxTest.php
@@ -18,7 +18,7 @@ class BlackBoxTest extends TestCase
      */
     private $adapter;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->adapter = getenv('ADAPTER');
         $this->client = new Client(['base_uri' => 'http://nginx:80/']);

--- a/tests/Test/BlackBoxTest.php
+++ b/tests/Test/BlackBoxTest.php
@@ -18,7 +18,7 @@ class BlackBoxTest extends TestCase
      */
     private $adapter;
 
-    public function setUp() : void
+    public function setUp(): void
     {
         $this->adapter = getenv('ADAPTER');
         $this->client = new Client(['base_uri' => 'http://nginx:80/']);


### PR DESCRIPTION
**Problem**
I think is a problem to have transport method hardcoded in line 81 cause it removes the flexibility of the code. 

**Solution**
I'm adding the viability of setting it in the constructor without the need of creating or setting a new client for it and letting the class handle the client.
I also made some fix on some standards like optional parameters at the end of function declaration and type hinted `$method` in `doRequest` function