### PR TITLE
Change read_timeout to be string

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Change the Redis options (the example shows the defaults):
         'port' => 6379,
         'password' => null,
         'timeout' => 0.1, // in seconds
-        'read_timeout' => 10, // in seconds
+        'read_timeout' => '10', // in seconds
         'persistent_connections' => false
     ]
 );

--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -22,7 +22,7 @@ class Redis implements Adapter
         'host' => '127.0.0.1',
         'port' => 6379,
         'timeout' => 0.1,
-        'read_timeout' => "10",
+        'read_timeout' => '10',
         'persistent_connections' => false,
         'password' => null,
     ];

--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -22,7 +22,7 @@ class Redis implements Adapter
         'host' => '127.0.0.1',
         'port' => 6379,
         'timeout' => 0.1,
-        'read_timeout' => 10,
+        'read_timeout' => "10",
         'persistent_connections' => false,
         'password' => null,
     ];


### PR DESCRIPTION
PHP gives error: TypeError: Redis::setOption() expects parameter 2 to be string 

This is because the read_timeout is set as an option, which must be a string. This should also be updated in the docs.