### PR TITLE
Allow overriding prefix via constructor

### DIFF
--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -25,12 +25,13 @@ class Redis implements Adapter
         'read_timeout' => '10',
         'persistent_connections' => false,
         'password' => null,
+        'prefix' => 'PROMETHEUS_',
     ];
 
     /**
      * @var string
      */
-    private static $prefix = 'PROMETHEUS_';
+    private static $prefix;
 
     /**
      * @var array
@@ -54,6 +55,7 @@ class Redis implements Adapter
     public function __construct(array $options = [])
     {
         $this->options = array_merge(self::$defaultOptions, $options);
+        static::setPrefix($this->options['prefix']);
         $this->redis = new \Redis();
     }
 


### PR DESCRIPTION
Initialize the prefix as part of the constructor and allow it to be set via the options. Eases ability to set a custom prefix as most users are not likely interacting with the Redis object directly, but rather sending in an options array via a higher-level loader.