### PR TITLE
Add typecasting for Redis connect function.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "endclothing/prometheus_client_php",
+    "name": "satariall/prometheus_client_php",
     "description": "Prometheus instrumentation library for PHP applications.",
     "type": "library",
     "license": "Apache-2.0",
@@ -15,7 +15,7 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^7.0.1",
         "symfony/polyfill-apcu": "^1.6"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "jimdo/prometheus_client_php": "*"
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.2||^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.0.1",
         "symfony/polyfill-apcu": "^1.6"

--- a/src/Prometheus/RenderTextFormat.php
+++ b/src/Prometheus/RenderTextFormat.php
@@ -56,6 +56,7 @@ class RenderTextFormat
      */
     private function escapeLabelValue($v): string
     {
+        $v = is_array($v) ? $v : (string) $v;
         $v = str_replace("\\", "\\\\", $v);
         $v = str_replace("\n", "\\n", $v);
         $v = str_replace("\"", "\\\"", $v);

--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -147,12 +147,12 @@ class Redis implements Adapter
             if ($this->options['persistent_connections']) {
                 return $this->redis->pconnect(
                     $this->options['host'],
-                    $this->options['port'],
-                    $this->options['timeout']
+                    (int)$this->options['port'],
+                    (float)$this->options['timeout']
                 );
             }
 
-            return $this->redis->connect($this->options['host'], $this->options['port'], $this->options['timeout']);
+            return $this->redis->connect($this->options['host'], (int)$this->options['port'], (float)$this->options['timeout']);
         } catch (\RedisException $e) {
             return false;
         }


### PR DESCRIPTION
Some libraries, frameworks of configs might provide a strings to port and timeout params. Redis extension on PHP 7.4 throw an TypeError on that situation. For preventing this add typecasting `(int)$this->options['port']` and `(float)$this->options['timeout']` to the `connect` and `pconnect` methods.