### PR TITLE
Make connection errors debuggable in Redis

### DIFF
--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -123,9 +123,6 @@ class Redis implements Adapter
         }
 
         $connectionStatus = $this->connectToServer();
-        if ($connectionStatus === false) {
-            throw new StorageException("Can't connect to Redis server", 0);
-        }
 
         if ($this->options['password']) {
             $this->redis->auth($this->options['password']);
@@ -140,6 +137,8 @@ class Redis implements Adapter
 
     /**
      * @return bool
+     *
+     * @throws StorageException
      */
     private function connectToServer(): bool
     {
@@ -154,7 +153,7 @@ class Redis implements Adapter
 
             return $this->redis->connect($this->options['host'], $this->options['port'], $this->options['timeout']);
         } catch (\RedisException $e) {
-            return false;
+            throw new StorageException("Can't connect to Redis server", 0, $e);
         }
     }
 


### PR DESCRIPTION
If there is an exception thrown during a redis connection, the actual error is completely hidden by the connectToServer method. This change allows debugging connection errors by placing the RedisException in the StorageException as a previous exception.