### PR TITLE
Prevent errors being thrown when calling registerGauge or registerCounter

### DIFF
--- a/src/Prometheus/CollectorRegistry.php
+++ b/src/Prometheus/CollectorRegistry.php
@@ -112,7 +112,7 @@ class CollectorRegistry
      * @throws MetricsRegistrationException
      */
     public function getOrRegisterGauge($namespace, $name, $help, $labels = []): Gauge
-    {   
+    {
         $metricIdentifier = self::metricIdentifier($namespace, $name);
         if (!isset($this->gauges[$metricIdentifier])) {
             return $this->registerGauge($namespace, $name, $help, $labels);

--- a/src/Prometheus/CollectorRegistry.php
+++ b/src/Prometheus/CollectorRegistry.php
@@ -112,13 +112,12 @@ class CollectorRegistry
      * @throws MetricsRegistrationException
      */
     public function getOrRegisterGauge($namespace, $name, $help, $labels = []): Gauge
-    {
-        try {
-            $gauge = $this->getGauge($namespace, $name);
-        } catch (MetricNotFoundException $e) {
-            $gauge = $this->registerGauge($namespace, $name, $help, $labels);
+    {   
+        $metricIdentifier = self::metricIdentifier($namespace, $name);
+        if (!isset($this->gauges[$metricIdentifier])) {
+            return $this->registerGauge($namespace, $name, $help, $labels);
         }
-        return $gauge;
+        return $this->gauges[$metricIdentifier];
     }
 
     /**
@@ -170,12 +169,11 @@ class CollectorRegistry
      */
     public function getOrRegisterCounter($namespace, $name, $help, $labels = []): Counter
     {
-        try {
-            $counter = $this->getCounter($namespace, $name);
-        } catch (MetricNotFoundException $e) {
-            $counter = $this->registerCounter($namespace, $name, $help, $labels);
+        $metricIdentifier = self::metricIdentifier($namespace, $name);
+        if (!isset($this->counters[$metricIdentifier])) {
+            return $this->registerCounter($namespace, $name, $help, $labels);
         }
-        return $counter;
+        return $this->counters[$metricIdentifier];
     }
 
     /**


### PR DESCRIPTION
While using XDebug in another app, I noticed errors continually being thrown in this file. It seems unexpected that these functions would throw an error, since the called functions are expected to perform the registration. We're going to ignore these files, but it might be worth adding this update.