### PR TITLE
Support Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^6.3|^7.0",
         "symfony/polyfill-apcu": "^1.6"
     },
     "require-dev": {


### PR DESCRIPTION
Guzzle 7 is now the latest version and also standard with the latest version of Laravel. This requires no changes to the library as the main changes are to take advantage of PHP 7, which this library already depends on.