### PR TITLE
fix passing null as 3rd argument to str_replace

### DIFF
--- a/src/Prometheus/RenderTextFormat.php
+++ b/src/Prometheus/RenderTextFormat.php
@@ -56,9 +56,9 @@ class RenderTextFormat
      */
     private function escapeLabelValue($v): string
     {
-        $v = str_replace("\\", "\\\\", $v);
-        $v = str_replace("\n", "\\n", $v);
-        $v = str_replace("\"", "\\\"", $v);
+        $v = str_replace("\\", "\\\\", $v ?? '');
+        $v = str_replace("\n", "\\n", $v ?? '');
+        $v = str_replace("\"", "\\\"", $v ?? '');
         return $v;
     }
 }


### PR DESCRIPTION
This is one of the forks we needed to create to make it work with php8. After the execution of end to end test, looking to kibana we can see lot of entries like ```app.CRITICAL: Uncaught PHP Exception TypeError: "str_replace(): Argument #3 ($subject) must be of type array|string, null given" at /www/vendor/endclothing/prometheus_client_php/src/Prometheus/RenderTextFormat.php line 59```

Error only happens in php8. This pr tries to fix 